### PR TITLE
Keep sorted data when changing page size or pagination

### DIFF
--- a/src/js/classes/ngReactGrid.js
+++ b/src/js/classes/ngReactGrid.js
@@ -299,7 +299,7 @@ NgReactGrid.prototype.updatePageSize = function (updates) {
     this.pageSize = updates.pageSize;
     this.currentPage = updates.currentPage;
     this.updateData({
-        data: (this.isSearching()) ? this.react.filteredData : this.react.originalData
+        data: this.react.filteredAndSortedData ? this.react.filteredAndSortedData : this.react.originalData
     }, true);
 };
 
@@ -310,7 +310,7 @@ NgReactGrid.prototype.updatePageSize = function (updates) {
 NgReactGrid.prototype.updatePagination = function (updates) {
     this.currentPage = updates.currentPage;
     this.updateData({
-        data: (this.isSearching()) ? this.react.filteredData : this.react.originalData
+        data: this.react.filteredAndSortedData ? this.react.filteredAndSortedData : this.react.originalData
     }, true);
 };
 


### PR DESCRIPTION
bug description:
when grid is sorted, changing page or changing page size cancel the sorting.

solution:
use the 'filteredAndSortedData' if exist when changing page or page size
