### PR TITLE
make isolated scope to the grid

### DIFF
--- a/src/js/directives/ngReactGridDirective.js
+++ b/src/js/directives/ngReactGridDirective.js
@@ -3,6 +3,9 @@ var ngReactGrid = require("../classes/NgReactGrid");
 var ngReactGridDirective = function ($rootScope) {
     return {
         restrict: "E",
+        scope : {
+            grid : "="
+        },
         link: function (scope, element, attrs) {
             new ngReactGrid(scope, element, attrs, $rootScope);
         }


### PR DESCRIPTION
The grid should have isolated scope for avoiding collisions.
sending all the data to the grid using the "grid" attribute on the directive.
