### PR TITLE
Add a way to override the default sort

### DIFF
--- a/src/js/classes/NgReactGridReactManager.js
+++ b/src/js/classes/NgReactGridReactManager.js
@@ -172,14 +172,34 @@ NgReactGridReactManager.prototype.performLocalSort = function (update) {
 
     var isAsc = update.sortInfo.dir === "asc";
 
+    /**
+     * Check if a custom sort function has been provided
+     */
+    var columnDef = this.ngReactGrid.columnDefs.filter(function(obj) {
+        return (obj.field !== undefined) && (obj.field === update.sortInfo.field);
+    });
+    var customSortFn;
+    if ((columnDef.length !== 0) && (columnDef[0].sortInfo !== undefined)) {
+        customSortFn = columnDef[0].sortInfo.sortFn;
+    }
+
     copy.sort(function (a, b) {
         var aField = this.getObjectPropertyByString(a, update.sortInfo.field);
         var bField = this.getObjectPropertyByString(b, update.sortInfo.field);
 
         if (isAsc) {
-            return aField <= bField ? -1 : 1;
+            if (customSortFn !== undefined) {
+                return customSortFn(aField, bField);
+            } else {
+                return aField <= bField ? -1 : 1;
+            }
+
         } else {
-            return aField >= bField ? -1 : 1;
+            if (customSortFn !== undefined) {
+                return customSortFn(bField, aField);
+            } else {
+                return aField >= bField ? -1 : 1;
+            }
         }
     }.bind(this));
 


### PR DESCRIPTION
Hi Jose,

First of all, thanks for ngReactGrid, it works well. We needed a way to be able to specify our custom sort on some columns, hence this first draft. Before we go further on this (the current PR is crude), just wanted to know your opinion on this feature. Would there be enough interest to warrant merging at some point?

Thanks.
