### PR TITLE
Fix the search box height

### DIFF
--- a/src/css/ngReactGrid.css
+++ b/src/css/ngReactGrid.css
@@ -69,7 +69,6 @@
     padding: 5px;
     padding-left: 9px;
     outline: none;
-    height: 15px;
 }
 
 .ngReactGrid .ngReactGridHeaderWrapper {


### PR DESCRIPTION
Maybe I'm the only one to see this, but the search box has an hardcoded CSS height that makes its content unreadable on my browser (Chrome 38 / Mac). See attached screenshots, before and after the patch.

Before :
![unreadable-searchbox](https://cloud.githubusercontent.com/assets/516479/5071410/d419b56a-6e70-11e4-8eb3-7e6e91ac3aa4.png)

After :
![correct-searchbox](https://cloud.githubusercontent.com/assets/516479/5071411/d794a092-6e70-11e4-8e47-81bac695d537.png)
