### PR TITLE
Fix the ngReactGridCheckbox column default width

### DIFF
--- a/src/js/factories/ngReactGridCheckboxFactory.js
+++ b/src/js/factories/ngReactGridCheckboxFactory.js
@@ -53,7 +53,7 @@ var ngReactGridCheckboxFactory = function($rootScope) {
                 return ngReactGridCheckboxComponent({selectionTarget: selectionTarget, handleClick: handleClick, row: row, options: _options});;
             },
             sort: false,
-            width: 1
+            width: 20
         }
     };
 


### PR DESCRIPTION
Like https://github.com/josebalius/ngReactGrid/pull/33, not sure if it is only on my browser, but the default checkbox column width is too small. Feel free to close abruptly if I'm the only one :)

Tested using a grid setup like this :

```
      $scope.grid = {
          data: [],
          columnDefs:[
              new ngReactGridCheckbox($scope.redactedSelected, { batchToggle: true }),
              { field: 'Time', displayName: 'Date',
...
```

Before :
![checkbox-column-width](https://cloud.githubusercontent.com/assets/516479/5071915/f3d668bc-6e75-11e4-9ea1-1be7e57fe5d5.png)

After :
![checkbox-column-width-corrected](https://cloud.githubusercontent.com/assets/516479/5071917/fb9e60ae-6e75-11e4-9647-c36781354b72.png)
