### PR TITLE
Fix typo error in css class name 'ngReactGridStatus'

### DIFF
--- a/src/jsx/reactGrid.jsx
+++ b/src/jsx/reactGrid.jsx
@@ -510,7 +510,7 @@ var NgReactGridComponent = (function() {
             render: function() {
 
                 return (
-                    <div className="NgReactGridStatus">
+                    <div className="ngReactGridStatus">
                         <div>Page <strong>{this.props.grid.currentPage}</strong> of <strong>{this.props.grid.totalPages}</strong> - Showing <strong>{this.props.grid.react.showingRecords}</strong> of <strong>{this.props.grid.totalCount}</strong> records</div>
                     </div>
                 )


### PR DESCRIPTION
Fix 'NgReactGridStatus' -> 'ngReactGridStatus' css class name.
