### PR TITLE
Switch to $watchCollection so that array operations on grid.data can be used

### DIFF
--- a/src/js/classes/ngReactGrid.js
+++ b/src/js/classes/ngReactGrid.js
@@ -203,7 +203,7 @@ NgReactGrid.prototype.setupUpdateEvents = function () {
  * Initializes the scope watchers needed for the grid
  */
 NgReactGrid.prototype.initWatchers = function () {
-    this.scope.$watch("grid.data", function (newValue, oldValue) {
+    this.scope.$watchCollection("grid.data", function (newValue, oldValue) {
         if (newValue !== oldValue) {
             if (this.isServerMode() && this.react.loading) {
                 this.react.loading = false;
@@ -215,7 +215,7 @@ NgReactGrid.prototype.initWatchers = function () {
         }
     }.bind(this));
 
-    this.scope.$watch("grid.columnDefs", function (newValue, oldValue) {
+    this.scope.$watchCollection("grid.columnDefs", function (newValue, oldValue) {
         if (newValue !== oldValue) {
             this.update(this.events.COLUMN_DEF, {
                 // Resets column filter fields


### PR DESCRIPTION
First I want to thank you for the great library!

Getting started I ran into a strange situation where pushing new data into the grid.data array didn't cause the grid to be updated. Looking at the code, I found that $watch was being used instead of $watchCollection which triggers an update when changes within the array happen.

This change makes the grid act more inline like a traditional grid when changing the data source.
